### PR TITLE
Fix fd redirect (unix)

### DIFF
--- a/src/core/intermediate_representation.rs
+++ b/src/core/intermediate_representation.rs
@@ -171,10 +171,7 @@ fn is_stdout_redirect(redirect: &ast::Redirect) -> bool {
         return false;
     }
 
-    match redirect.redirectee {
-        ast::Redirectee::Filename(_) => true,
-        _ => false,
-    }
+    true
 }
 
 /// Gets the last stderr redirect in `redirects`
@@ -265,6 +262,18 @@ mod tests {
             redirector: Some(ast::Redirectee::FileDescriptor(fd)),
             instruction: ast::RedirectInstruction::Output,
             redirectee: ast::Redirectee::Filename(filename.into()),
+        }
+    }
+
+    fn fd_to_fd_redirection(
+        input_fd: i32,
+        instruction: ast::RedirectInstruction,
+        output_fd: i32,
+    ) -> ast::Redirect {
+        ast::Redirect {
+            redirector: Some(ast::Redirectee::FileDescriptor(input_fd)),
+            instruction,
+            redirectee: ast::Redirectee::FileDescriptor(output_fd),
         }
     }
 
@@ -433,6 +442,35 @@ mod tests {
                 background: false,
             }
         );
+    }
+
+    #[test]
+    fn test_redirect_stderr_file() {
+        let input = "2>errfile >&2 echo needle".to_string();
+        assert_eq!(
+            Interpreter::parse(parser::Command {
+                input: input.clone(),
+                inner: ast::Command::Simple {
+                    words: vec!["echo".into(), "needle".into()],
+                    redirects: vec![
+                        fd_to_file_redirection(2, "errfile"),
+                        fd_to_fd_redirection(1, ast::RedirectInstruction::Output, 2),
+                    ],
+                    background: false,
+                },
+            }),
+            CommandGroup {
+                input,
+                command: Command::Simple(
+                    SimpleCommandBuilder::new("echo")
+                        .arg("needle")
+                        .stdout(Stdio::FileDescriptor(2))
+                        .stderr(Stdio::Filename("errfile".into()))
+                        .build()
+                ),
+                background: false
+            }
+        )
     }
 
     #[test]

--- a/src/core/intermediate_representation.rs
+++ b/src/core/intermediate_representation.rs
@@ -193,10 +193,7 @@ fn is_stderr_redirect(redirect: &ast::Redirect) -> bool {
         return false;
     }
 
-    match redirect.redirectee {
-        ast::Redirectee::Filename(_) => true,
-        _ => false,
-    }
+    true
 }
 
 #[cfg(test)]

--- a/src/core/parser/ast.rs
+++ b/src/core/parser/ast.rs
@@ -129,6 +129,14 @@ mod tests {
         }
     }
 
+    fn output_fd_redirection(fd: i32) -> Redirect {
+        Redirect {
+            redirector: None,
+            instruction: RedirectInstruction::Output,
+            redirectee: Redirectee::FileDescriptor(fd),
+        }
+    }
+
     fn fd_to_file_redirection(fd: i32, filename: &str) -> Redirect {
         Redirect {
             redirector: Some(Redirectee::FileDescriptor(fd)),
@@ -277,6 +285,20 @@ mod tests {
             Command::Simple {
                 words: vec!["echo".into(), "bob".into()],
                 redirects: vec![output_filename_redirection("out"), input_redirection("in"),],
+                background: false,
+            }
+        );
+
+        assert_eq!(
+            CommandParser::new()
+                .parse("2>errfile >&2 echo needle",)
+                .expect("'2>errfile >&2 echo needle' should be valid",),
+            Command::Simple {
+                words: vec!["echo".into(), "needle".into()],
+                redirects: vec![
+                    fd_to_file_redirection(2, "errfile"),
+                    output_fd_redirection(2),
+                ],
                 background: false,
             }
         );

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,27 +17,32 @@ impl Error {
         self.ctx.get_context()
     }
 
-    pub(crate) fn syntax<T: AsRef<str>>(line: T) -> Error {
+    pub(crate) fn syntax<T: AsRef<str>>(line: T) -> Self {
         Error::from(ErrorKind::Syntax(line.as_ref().to_string()))
     }
 
-    pub(crate) fn builtin_command<T: AsRef<str>>(message: T, code: i32) -> Error {
+    pub(crate) fn builtin_command<T: AsRef<str>>(message: T, code: i32) -> Self {
         Error::from(ErrorKind::BuiltinCommand {
             message: message.as_ref().to_string(),
             code,
         })
     }
 
-    pub(crate) fn command_not_found<T: AsRef<str>>(command: T) -> Error {
+    pub(crate) fn command_not_found<T: AsRef<str>>(command: T) -> Self {
         Error::from(ErrorKind::CommandNotFound(command.as_ref().to_string()))
     }
 
-    pub(crate) fn no_such_job<T: AsRef<str>>(job: T) -> Error {
+    pub(crate) fn no_such_job<T: AsRef<str>>(job: T) -> Self {
         Error::from(ErrorKind::NoSuchJob(job.as_ref().to_string()))
     }
 
-    pub(crate) fn no_job_control() -> Error {
+    pub(crate) fn no_job_control() -> Self {
         Error::from(ErrorKind::NoJobControl)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn not_supported<T: AsRef<str>>(message: T) -> Self {
+        Error::from(ErrorKind::NotSupported(message.as_ref().to_string()))
     }
 }
 
@@ -65,6 +70,7 @@ pub enum ErrorKind {
     HistoryFileNotFound,
     NoSuchJob(String),
     NoJobControl,
+    NotSupported(String),
     Docopt,
     Io,
     Nix,
@@ -80,6 +86,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::HistoryFileNotFound => write!(f, "history file not found"),
             ErrorKind::NoSuchJob(ref job) => write!(f, "{}: no such job", job),
             ErrorKind::NoJobControl => write!(f, "no job control"),
+            ErrorKind::NotSupported(ref message) => write!(f, "{}", message),
             ErrorKind::Docopt => write!(f, "Docopt error occurred"),
             ErrorKind::Io => write!(f, "I/O error occurred"),
             ErrorKind::Nix => write!(f, " Nix error occurred"),

--- a/src/execute_command.rs
+++ b/src/execute_command.rs
@@ -8,7 +8,6 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
 
 use failure::{Fail, ResultExt};
-use log::warn;
 
 use crate::{
     builtins,
@@ -599,6 +598,8 @@ where
         Ok(child) => child,
         Err(e) => {
             if job_control_is_enabled {
+                use log::warn;
+
                 warn!("failed to spawn child, resetting terminal's pgrp");
                 // see above comment for tcsetpgrp(2) failing being programmer
                 // error

--- a/src/execute_command.rs
+++ b/src/execute_command.rs
@@ -21,13 +21,23 @@ use crate::{
 pub enum Stdin {
     Inherit,
     File(File),
+    FileDescriptor(i32),
     Child(ChildStdout),
 }
 
 #[derive(Debug)]
-enum Output {
+enum Stdout {
     Inherit,
     File(File),
+    FileDescriptor(i32),
+    CreatePipe,
+}
+
+#[derive(Debug)]
+enum Stderr {
+    Inherit,
+    File(File),
+    FileDescriptor(i32),
     CreatePipe,
 }
 
@@ -35,11 +45,9 @@ impl Stdin {
     /// simple commands prefer file redirects to piping, following bash's behavior
     #[cfg(unix)]
     fn new(redirect: &ir::Stdio, pipe: Option<Stdin>) -> Result<Self> {
-        use std::os::unix::io::FromRawFd;
-
         match (redirect, pipe) {
             (ir::Stdio::FileDescriptor(0), _) => Ok(Stdin::Inherit),
-            (ir::Stdio::FileDescriptor(fd), _) => unsafe { Ok(File::from_raw_fd(*fd).into()) },
+            (ir::Stdio::FileDescriptor(fd), _) => Ok(Stdin::FileDescriptor(*fd)),
             (ir::Stdio::Filename(filename), _) => Ok(Stdin::File(
                 File::open(filename).with_context(|_| ErrorKind::Io)?,
             )),
@@ -58,43 +66,6 @@ impl Stdin {
             )),
             (_, Some(stdin)) => Ok(stdin),
             _ => Ok(Stdin::Inherit),
-        }
-    }
-}
-
-impl Output {
-    /// simple commands prefer file redirects to piping, following bash's behavior
-    #[cfg(unix)]
-    fn new(redirect: &ir::Stdio, pipe: Option<Output>) -> Result<Self> {
-        use std::os::unix::io::FromRawFd;
-
-        match (redirect, pipe) {
-            (ir::Stdio::FileDescriptor(fd), _) => unsafe { Ok(File::from_raw_fd(*fd).into()) },
-            (ir::Stdio::Filename(filename), _) => Ok(Output::File(
-                OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .open(filename)
-                    .context(ErrorKind::Io)?,
-            )),
-            (_, Some(output)) => Ok(output),
-            _ => Ok(Output::Inherit),
-        }
-    }
-
-    #[cfg(windows)]
-    fn new(redirect: &ir::Stdio, pipe: Option<Output>) -> Result<Self> {
-        match (redirect, pipe) {
-            (ir::Stdio::FileDescriptor(_fd), _) => unimplemented!(),
-            (ir::Stdio::Filename(filename), _) => Ok(Output::File(
-                OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .open(filename)
-                    .context(ErrorKind::Io)?,
-            )),
-            (_, Some(output)) => Ok(output),
-            _ => Ok(Output::Inherit),
         }
     }
 }
@@ -113,33 +84,116 @@ impl AsRawFd for Stdin {
         match self {
             Stdin::Inherit => libc::STDIN_FILENO,
             Stdin::File(f) => f.as_raw_fd(),
+            Stdin::FileDescriptor(fd) => *fd,
             Stdin::Child(child) => child.as_raw_fd(),
         }
     }
 }
 
-impl From<File> for Output {
-    fn from(file: File) -> Self {
-        Output::File(file)
+impl Stdout {
+    /// simple commands prefer file redirects to piping, following bash's behavior
+    #[cfg(unix)]
+    fn new(redirect: &ir::Stdio, pipe: Option<Stdout>) -> Result<Self> {
+        match (redirect, pipe) {
+            (ir::Stdio::FileDescriptor(1), _) => Ok(Stdout::Inherit),
+            (ir::Stdio::FileDescriptor(fd), _) => Ok(Stdout::FileDescriptor(*fd)),
+            (ir::Stdio::Filename(filename), _) => Ok(Stdout::File(
+                OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(filename)
+                    .context(ErrorKind::Io)?,
+            )),
+            (_, Some(output)) => Ok(output),
+            _ => Ok(Stdout::Inherit),
+        }
     }
-}
 
-impl From<Stdin> for Stdio {
-    fn from(stdin: Stdin) -> Self {
-        match stdin {
-            Stdin::Inherit => Self::inherit(),
-            Stdin::File(file) => file.into(),
-            Stdin::Child(child) => child.into(),
+    #[cfg(windows)]
+    fn new(redirect: &ir::Stdio, pipe: Option<Stdout>) -> Result<Self> {
+        match (redirect, pipe) {
+            (ir::Stdio::FileDescriptor(1), _) => Ok(Stdout::Inherit),
+            (ir::Stdio::FileDescriptor(_fd), _) => unimplemented!(),
+            (ir::Stdio::Filename(filename), _) => Ok(Stdout::File(
+                OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(filename)
+                    .context(ErrorKind::Io)?,
+            )),
+            (_, Some(output)) => Ok(output),
+            _ => Ok(Stdout::Inherit),
         }
     }
 }
 
-impl From<Output> for Stdio {
-    fn from(stdout: Output) -> Self {
+impl From<File> for Stdout {
+    fn from(file: File) -> Self {
+        Stdout::File(file)
+    }
+}
+
+impl From<Stdout> for Stdio {
+    fn from(stdout: Stdout) -> Self {
         match stdout {
-            Output::Inherit => Self::inherit(),
-            Output::File(file) => file.into(),
-            Output::CreatePipe => Self::piped(),
+            Stdout::Inherit => Self::inherit(),
+            Stdout::File(file) => file.into(),
+            Stdout::FileDescriptor(_fd) => panic!("must occur after fork(2)"),
+            Stdout::CreatePipe => Self::piped(),
+        }
+    }
+}
+
+impl Stderr {
+    /// simple commands prefer file redirects to piping, following bash's behavior
+    #[cfg(unix)]
+    fn new(redirect: &ir::Stdio, pipe: Option<Stderr>) -> Result<Self> {
+        match (redirect, pipe) {
+            (ir::Stdio::FileDescriptor(2), _) => Ok(Stderr::Inherit),
+            (ir::Stdio::FileDescriptor(fd), _) => Ok(Stderr::FileDescriptor(*fd)),
+            (ir::Stdio::Filename(filename), _) => Ok(Stderr::File(
+                OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(filename)
+                    .context(ErrorKind::Io)?,
+            )),
+            (_, Some(output)) => Ok(output),
+            _ => Ok(Stderr::Inherit),
+        }
+    }
+
+    #[cfg(windows)]
+    fn new(redirect: &ir::Stdio, pipe: Option<Stderr>) -> Result<Self> {
+        match (redirect, pipe) {
+            (ir::Stdio::FileDescriptor(2), _) => Ok(Stderr::Inherit),
+            (ir::Stdio::FileDescriptor(_fd), _) => unimplemented!(),
+            (ir::Stdio::Filename(filename), _) => Ok(Stderr::File(
+                OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(filename)
+                    .context(ErrorKind::Io)?,
+            )),
+            (_, Some(output)) => Ok(output),
+            _ => Ok(Stderr::Inherit),
+        }
+    }
+}
+
+impl From<File> for Stderr {
+    fn from(file: File) -> Self {
+        Stderr::File(file)
+    }
+}
+
+impl From<Stderr> for Stdio {
+    fn from(stderr: Stderr) -> Self {
+        match stderr {
+            Stderr::Inherit => Self::inherit(),
+            Stderr::File(file) => file.into(),
+            Stderr::FileDescriptor(_fd) => panic!("must occur after fork(2)"),
+            Stderr::CreatePipe => Self::piped(),
         }
     }
 }
@@ -349,14 +403,14 @@ fn _spawn_processes(
     shell: &mut dyn Shell,
     command: &ir::Command,
     stdin: Option<Stdin>,
-    stdout: Option<Output>,
+    stdout: Option<Stdout>,
     pgid: Option<u32>,
 ) -> Result<(Vec<Box<dyn Process>>, Option<u32>)> {
     match command {
         ir::Command::Simple(simple_command) => {
             let stdin = Stdin::new(&simple_command.stdin, stdin)?;
-            let stdout = Output::new(&simple_command.stdout, stdout)?;
-            let stderr = Output::new(&simple_command.stderr, None /*pipe*/)?;
+            let stdout = Stdout::new(&simple_command.stdout, stdout)?;
+            let stderr = Stderr::new(&simple_command.stderr, None /*pipe*/)?;
             let (result, pgid) = run_simple_command(
                 shell,
                 &simple_command.program,
@@ -381,8 +435,8 @@ fn run_simple_command<S1, S2>(
     program: S1,
     args: &[S2],
     stdin: Stdin,
-    stdout: Output,
-    stderr: Output,
+    stdout: Stdout,
+    stderr: Stderr,
     pgid: Option<u32>,
 ) -> Result<(Box<dyn Process>, Option<u32>)>
 where
@@ -402,13 +456,13 @@ fn run_connection_command(
     second: &ir::Command,
     connector: ast::Connector,
     stdin: Option<Stdin>,
-    stdout: Option<Output>,
+    stdout: Option<Stdout>,
     pgid: Option<u32>,
 ) -> Result<(Vec<Box<dyn Process>>, Option<u32>)> {
     match connector {
         ast::Connector::Pipe => {
             let (mut first_result, pgid) =
-                _spawn_processes(shell, first, stdin, Some(Output::CreatePipe), pgid)?;
+                _spawn_processes(shell, first, stdin, Some(Stdout::CreatePipe), pgid)?;
             let (second_result, pgid) = _spawn_processes(
                 shell,
                 second,
@@ -469,7 +523,7 @@ fn run_builtin_command<S1, S2>(
     shell: &mut dyn Shell,
     program: S1,
     args: &[S2],
-    stdout: Output,
+    stdout: Stdout,
     pgid: Option<u32>,
 ) -> Result<(Box<dyn Process>, Option<u32>)>
 where
@@ -479,15 +533,16 @@ where
     // TODO(rogardn): change Result usage in builtin to only be for rust
     // errors, e.g. builtin::execute shouldn't return a Result
     let (status_code, output) = match stdout {
-        Output::File(mut file) => (builtins::run(shell, &program, args, &mut file).0, None),
-        Output::CreatePipe => {
+        Stdout::File(mut file) => (builtins::run(shell, &program, args, &mut file).0, None),
+        Stdout::FileDescriptor(_fd) => unimplemented!(),
+        Stdout::CreatePipe => {
             let (read_end_pipe, mut write_end_pipe) = create_pipe()?;
             (
                 builtins::run(shell, &program, args, &mut write_end_pipe).0,
                 Some(read_end_pipe.into()),
             )
         }
-        Output::Inherit => (
+        Stdout::Inherit => (
             builtins::run(shell, &program, args, &mut io::stdout()).0,
             None,
         ),
@@ -505,8 +560,8 @@ fn run_external_command<S1, S2>(
     program: S1,
     args: &[S2],
     stdin: Stdin,
-    stdout: Output,
-    stderr: Output,
+    stdout: Stdout,
+    stderr: Stderr,
     pgid: Option<u32>,
 ) -> Result<(Box<dyn Process>, Option<u32>)>
 where
@@ -532,8 +587,19 @@ where
     // to configure stdin here, then stdin would be changed before our code
     // executes in before_exec, so if the child is not the first process in the
     // pipeline, its stdin would not be a tty and tcsetpgrp would tell us so.
-    command.stdout(stdout);
-    command.stderr(stderr);
+    let stdout_fd = if let Stdout::FileDescriptor(fd) = stdout {
+        Some(fd)
+    } else {
+        command.stdout(stdout);
+        None
+    };
+
+    let stderr_fd = if let Stderr::FileDescriptor(fd) = stderr {
+        Some(fd)
+    } else {
+        command.stderr(stderr);
+        None
+    };
 
     let job_control_is_enabled = shell.is_job_control_enabled();
     let shell_terminal = util::unix::get_terminal();
@@ -589,6 +655,20 @@ where
             unistd::close(stdin).expect("failed to close stdin");
         }
 
+        if let Some(fd) = stdout_fd {
+            if fd != libc::STDOUT_FILENO {
+                unistd::dup2(fd, libc::STDOUT_FILENO).expect("failed to dup stdout");
+                unistd::close(fd).expect("failed to close stdout");
+            }
+        }
+
+        if let Some(fd) = stderr_fd {
+            if fd != libc::STDERR_FILENO {
+                unistd::dup2(fd, libc::STDERR_FILENO).expect("failed to dup stderr");
+                unistd::close(fd).expect("failed to close stderr");
+            }
+        }
+
         Ok(())
     });
 
@@ -637,8 +717,8 @@ fn run_external_command<S1, S2>(
     program: S1,
     args: &[S2],
     stdin: Stdin,
-    stdout: Output,
-    stderr: Output,
+    stdout: Stdout,
+    stderr: Stderr,
     pgid: Option<u32>,
 ) -> Result<(Box<Process>, Option<u32>)>
 where

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -124,7 +124,7 @@ fn test_simple_redirects() {
 #[cfg(unix)] // TODO (#22): Support Windows
 fn test_stderr_redirect() {
     let temp_dir = generate_temp_directory().unwrap();
-    let command = r#"python3 -c 'import sys; print("test needle", file=sys.stderr)' 2>errfile"#;
+    let command = "2>errfile >&2 echo needle";
     BIN_UNDER_TEST
         .command()
         .args(&[OsStr::new("--log"), LOG_FILE_NAME.as_os_str()])
@@ -138,7 +138,7 @@ fn test_stderr_redirect() {
     let mut contents = String::new();
     file.read_to_string(&mut contents)
         .expect("failed to read errfile");
-    assert_eq!(contents, "test needle\n");
+    assert_eq!(contents, "needle\n");
 }
 
 #[test]


### PR DESCRIPTION
This fixes several bugs:

1. stdout/stderr fd redirect duplications were mis-categorized due to redirector requiring filename
   - fixed by relaxing `is_stdout_redirect` and `is_stderr_redirect` and added new tests
2. stdout/stderr fd redirect duplications were causing double-close on file descriptor
   - fixed by adding new FileDescriptor variants and manually dup+close in `before_exec` (unix-only)