### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rust:
 matrix:
   fast_finish: true
 before_script:
-  - rustup self update
-  - rustup component add clippy
+  - rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
   - rustup component add rustfmt
 script: ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ matrix:
   fast_finish: true
 before_script:
   # best-effort install clippy
-  - rustup component add clippy ||
-      cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy &&
-      export CLIPPY_NIGHTLY_INSTALLED=1 || true
+  - ((rustup component add clippy ||
+      cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy) &&
+      export CLIPPY_NIGHTLY_INSTALLED=1) || true
   - rustup component add rustfmt
 script: ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ rust:
 matrix:
   fast_finish: true
 before_script:
-  - rustup component add clippy-preview
-  - rustup component add rustfmt-preview
+  - rustup component add clippy
+  - rustup component add rustfmt
 script: ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
   fast_finish: true
 before_script:
   # best-effort install clippy
-  - rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy || true
+  - rustup component add clippy ||
+      cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy &&
+      export CLIPPY_NIGHTLY_INSTALLED=1 || true
   - rustup component add rustfmt
 script: ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rust:
 matrix:
   fast_finish: true
 before_script:
+  - rustup self update
   - rustup component add clippy
   - rustup component add rustfmt
 script: ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rust:
 matrix:
   fast_finish: true
 before_script:
-  - rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
+  # best-effort install clippy
+  - rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy || true
   - rustup component add rustfmt
 script: ci/script.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -62,7 +62,7 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -74,7 +74,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -85,7 +85,7 @@ version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -140,9 +140,9 @@ dependencies = [
  "lalrpop 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.11.0 (git+https://github.com/rgardner/nix?branch=implement-libc-signal)",
+ "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -212,7 +212,7 @@ name = "dirs"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -416,12 +416,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.43"
-source = "git+https://github.com/rust-lang/libc#78d53920c32d35dfbce7c39b2b2939da204b58e2"
-
-[[package]]
-name = "libc"
-version = "0.2.43"
+version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -438,7 +433,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -453,24 +448,24 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.11.0"
-source = "git+https://github.com/rgardner/nix?branch=implement-libc-signal#a8a05f4c1892dc2ba31108dd313e751f3fc46060"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (git+https://github.com/rust-lang/libc)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
-version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -597,7 +592,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -608,7 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -706,7 +701,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -848,7 +843,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -869,7 +864,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -887,7 +882,7 @@ name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1027,13 +1022,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "60c6c48ba857cd700673ce88907cadcdd7e2cd7783ed02378537c5ffd4f6460c"
 "checksum lalrpop-util 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2400aeebcd11259370d038c24821b93218dd2f33a53f53e9c8fcccca70be6696"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
-"checksum libc 0.2.43 (git+https://github.com/rust-lang/libc)" = "<none>"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
 "checksum new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cdc457076c78ab54d5e0d6fa7c47981757f1e34dc39ff92787f217dede586c4"
-"checksum nix 0.11.0 (git+https://github.com/rgardner/nix?branch=implement-libc-signal)" = "<none>"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
+"checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ path = "src/bin/bsh.rs"
 lalrpop = "0.15.2"
 
 [dependencies]
+atty = "0.2.11"
+cfg-if = "0.1.5"
 dirs = "1.0.4"
 docopt = "1.0.1"
 failure = "0.1.2"
@@ -23,16 +25,11 @@ fern = "0.5.6"
 lalrpop-util = "0.16.0"
 libc = "0.2.43"
 log = "0.4.5"
+nix = "0.13.0"
 regex = "1.0.5"
 rustyline = "2.1.0"
 serde = "1.0.79"
 serde_derive = "1.0.79"
-atty = "0.2.11"
-cfg-if = "0.1.5"
-
-[dependencies.nix]
-branch = "implement-libc-signal"
-git = "https://github.com/rgardner/nix"
 
 [dev-dependencies]
 assert_cmd = "0.10.1"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ shell program](https://github.com/rgardner/bsh).
 * contribute back to the Rust ecosystem
   - [rustyline: Add `const` way of accessing editor history](https://github.com/kkawakam/rustyline/commit/f536c969e73bb121a3968b71342db5dba4e885fa)
   - [rustyline: Fix multi-line prompts clearing too many lines](https://github.com/kkawakam/rustyline/commit/59c4b7b045870127405da4ef8345cd917740166f)
-  - [nix (in-progress): add wrapper for signal(3) function](https://github.com/nix-rust/nix/pull/817)
+  - [nix: add wrapper for signal(3) function](https://github.com/nix-rust/nix/commit/6bff42166472c929a3871e3f7f2a7bc4d9b77e6a)
 
 
 ## Usage

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -12,7 +12,7 @@ cargo build --verbose
 cargo fmt --all -- --check
 
 # best-effort run clippy
-if [ -n {CLIPPY_NIGHTLY_INSTALLED} ]; then
+if [ -n "$CLIPPY_NIGHTLY_INSTALLED" ]; then
   cargo clippy --all-targets
 fi
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -17,4 +17,3 @@ if [ -n {CLIPPY_NIGHTLY_INSTALLED} ]; then
 fi
 
 cargo test --verbose
-cargo test --release --verbose

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,9 +1,20 @@
-#!/usr/bin/env bash
+#!/bin/bash
+#
+# Builds and run tests for bsh.
 
+# Exit immediately if a command fails
+# Print commands and their arguments
 set -ex
 
 cargo build --verbose
-cargo fmt --all -- --check # precondition: built grammar first
+
+# precondition: built grammar first via cargo build
+cargo fmt --all -- --check
+
 # best-effort run clippy
-[[ -n {CLIPPY_NIGHTLY_INSTALLED} ]] && cargo clippy --all-targets
+if [ -n {CLIPPY_NIGHTLY_INSTALLED} ]; then
+  cargo clippy --all-targets
+fi
+
 cargo test --verbose
+cargo test --release --verbose

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,5 +5,5 @@ set -ex
 cargo build --verbose
 cargo fmt --all -- --check # precondition: built grammar first
 # best-effort run clippy
-command -V cargo-clippy && cargo clippy --all-targets
+[[ -n {CLIPPY_NIGHTLY_INSTALLED} ]] && cargo clippy --all-targets
 cargo test --verbose

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,5 +4,6 @@ set -ex
 
 cargo build --verbose
 cargo fmt --all -- --check # precondition: built grammar first
-cargo clippy --all-targets
+# best-effort run clippy
+command -V cargo-clippy && cargo clippy --all-targets
 cargo test --verbose

--- a/src/builtins/env.rs
+++ b/src/builtins/env.rs
@@ -100,14 +100,12 @@ mod tests {
 
         let key = generate_unique_env_key!();
         let value = "bar";
-        assert!(
-            Declare::run(
-                &mut *shell,
-                &["=baz", &format!("{}={}", key, value), "=baz"],
-                &mut io::sink(),
-            )
-            .is_err()
-        );
+        assert!(Declare::run(
+            &mut *shell,
+            &["=baz", &format!("{}={}", key, value), "=baz"],
+            &mut io::sink(),
+        )
+        .is_err());
         assert_eq!(env::var(key).unwrap(), value);
     }
 
@@ -120,25 +118,21 @@ mod tests {
         assert_eq!(&env::var(&key).unwrap(), "");
 
         let value1 = "bar";
-        assert!(
-            Declare::run(
-                &mut *shell,
-                &[&format!("{}={}", key, value1)],
-                &mut io::sink(),
-            )
-            .is_ok()
-        );
+        assert!(Declare::run(
+            &mut *shell,
+            &[&format!("{}={}", key, value1)],
+            &mut io::sink(),
+        )
+        .is_ok());
         assert_eq!(env::var(&key).unwrap(), value1);
 
         let value2 = "baz";
-        assert!(
-            Declare::run(
-                &mut *shell,
-                &[format!("{}={}", key, value2)],
-                &mut io::sink(),
-            )
-            .is_ok()
-        );
+        assert!(Declare::run(
+            &mut *shell,
+            &[format!("{}={}", key, value2)],
+            &mut io::sink(),
+        )
+        .is_ok());
         assert_eq!(env::var(&key).unwrap(), value2);
     }
 
@@ -149,14 +143,12 @@ mod tests {
         let key1 = generate_unique_env_key!();
         let key2 = generate_unique_env_key!();
         let value = "baz";
-        assert!(
-            Declare::run(
-                &mut *shell,
-                &[format!("{}={}", key1, value), format!("{}={}", key2, value)],
-                &mut io::sink(),
-            )
-            .is_ok()
-        );
+        assert!(Declare::run(
+            &mut *shell,
+            &[format!("{}={}", key1, value), format!("{}={}", key2, value)],
+            &mut io::sink(),
+        )
+        .is_ok());
         assert_eq!(env::var(&key1).unwrap(), value);
         assert_eq!(env::var(&key2).unwrap(), value);
     }

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -77,7 +77,7 @@ pub fn is_builtin<T: AsRef<str>>(program: T) -> bool {
         JOBS_NAME,
         UNSET_NAME,
     ]
-        .contains(&program.as_ref())
+    .contains(&program.as_ref())
 }
 
 /// precondition: command is a builtin.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -20,8 +20,8 @@ lazy_static! {
             "log",
             &format!("test-{}.log", log_name),
         ]
-            .iter()
-            .collect()
+        .iter()
+        .collect()
     };
     static ref BIN_UNDER_TEST: escargot::CargoRun = escargot::CargoBuild::new()
         .bin("bsh")


### PR DESCRIPTION
The CI build was failing for multiple reasons:

* clippy failed to build in the latest nightly, so it failed to install on the CI build.
* rustfmt updated and needed to be re-run on the project

This change fixes the build to best-effort install and run clippy. If clippy is installed, it will run and fail the build if a clippy violation is found. If clippy is not installed, this check will be skipped.

nix 0.13.0 includes my sys::signal::signal function, so the custom
fork is no longer needed.

Closes #12